### PR TITLE
bugfix: finaliter could have been run on un-selfcal'd data if the scripts were re-run

### DIFF
--- a/reduction/continuum_imaging_selfcal.py
+++ b/reduction/continuum_imaging_selfcal.py
@@ -754,6 +754,22 @@ for continuum_ms in continuum_mses:
                  origin='contim_selfcal')
 
 
+
+
+    # finaliter section begins here
+
+
+    # make sure the calibration tables have been applied, otherwise re-runs can
+    # result in starting from un-corrected data
+    if not dryrun:
+        clearcal(vis=selfcal_ms, addmodel=True)
+        # use gainfield so we interpolate the good solutions to the other
+        # fields
+        assert len(cals) >= selfcaliter
+        applycal(vis=selfcal_ms, gainfield=okfields_str, gaintable=cals,
+                 interp="linear", applymode='calonly', calwt=False)
+
+
     for robust in (0, -2, 2):
         logprint("Imaging self-cal iter {0} (final) with robust {1}"
                  .format(selfcaliter, robust),


### PR DESCRIPTION
This fixes a bug where re-running the scripts could have run finaliter on un-selfcal'd data.  Technically, this was unlikely to happen unless you ran clearcal or did something else weird, but now this won't be allowed to happen.