### PR TITLE
Change imaging parameters as Roberto suggested

### DIFF
--- a/reduction/imaging_parameters.py
+++ b/reduction/imaging_parameters.py
@@ -1169,13 +1169,13 @@ selfcal_pars["G008.67_B3_12M_robust0_bsens"][5] = {"solint": "200s", "gaintype":
 
 line_imaging_parameters = {
     "{0}_{1}_{2}_robust{3}{4}".format(field, band, array, robust, contsub): {
-        "niter": 100000,  # start with a light cleaning...
+        "niter": 1000000,  # start with a light cleaning...
         "robust": robust,
         "weighting": "briggs",
-        "scales": [0, 3, 9, 27, 81],
+        #"scales": [0, 3, 9, 27, 81],
         "gridder": "mosaic",
         "specmode": "cube",
-        "deconvolver": "multiscale",
+        "deconvolver": "hogbom",
         "outframe": "LSRK",
         "veltype": "radio",
         "sidelobethreshold": 2.0,
@@ -1183,8 +1183,9 @@ line_imaging_parameters = {
         "usemask": "auto-multithresh",
         "threshold": "5sigma",
         "interactive": False,
-        "pblimit": 0.0,
+        "pblimit": 0.1,
         "nterms": 1,
+        "perchanweightdensity": False,
     }
     for field in allfields
     for band in ("B3", "B6")

--- a/reduction/imaging_parameters.py
+++ b/reduction/imaging_parameters.py
@@ -1169,23 +1169,28 @@ selfcal_pars["G008.67_B3_12M_robust0_bsens"][5] = {"solint": "200s", "gaintype":
 
 line_imaging_parameters = {
     "{0}_{1}_{2}_robust{3}{4}".format(field, band, array, robust, contsub): {
-        "niter": 1000000,  # start with a light cleaning...
+        "niter": 5000000,  # start with a light cleaning...
+        "threshold": "8sigma",
         "robust": robust,
         "weighting": "briggs",
+        "deconvolver": "hogbom",
         #"scales": [0, 3, 9, 27, 81],
+        #"nterms": 1,
         "gridder": "mosaic",
         "specmode": "cube",
-        "deconvolver": "hogbom",
         "outframe": "LSRK",
         "veltype": "radio",
-        "sidelobethreshold": 2.0,
-        "noisethreshold": 5.0,
         "usemask": "auto-multithresh",
-        "threshold": "5sigma",
-        "interactive": False,
-        "pblimit": 0.1,
-        "nterms": 1,
+        "sidelobethreshold": 2.0,
+        "noisethreshold": 4.2,
+        "lownoisethreshold": 1.5,
+        "minbeamfrac": 0.3,
+        "negativethreshold": 15, 
+        "pblimit": 0.,
+        "pbmask": 0.2,
+        "pbcor": True,
         "perchanweightdensity": False,
+        "interactive": False,
     }
     for field in allfields
     for band in ("B3", "B6")


### PR DESCRIPTION
As per suggestions in the latest meeting, this PR boosts the default niter to 1 million. and drops multiscale cleaning in favor of hogbom.

@rgalvanmadrid were there changes to be made to the automultithresh parameters too?