### PR TITLE
Sanitize cont.dat usage

### DIFF
--- a/reduction/line_imaging.py
+++ b/reduction/line_imaging.py
@@ -51,6 +51,8 @@ ms = mstool()
 
 with open('to_image.json', 'r') as fh:
     to_image = json.load(fh)
+with open('metadata.json', 'r') as fh:
+    metadata = json.load(fh)
 
 if os.getenv('LOGFILENAME'):
     casalog.setlogfile(os.path.join(os.getcwd(), os.getenv('LOGFILENAME')))
@@ -305,34 +307,15 @@ for band in band_list:
                     concat(vis=vis, concatvis=concatvis)
 
             if do_contsub:
-                # the cont_channel_selection is purely in frequency, so it should
-                # "just work"
-                # (there may be several cont.dats - we're just grabbing the first)
-                # Different data sets are actually found to have different channel selections.
-                path = os.path.split(vis[0])[0]
-
 
                 if not os.path.exists(concatvis+".contsub"):
                     logprint("Concatvis contsub {0}.contsub does not exist, doing continuum subtraction.".format(str(concatvis)),
                              origin='almaimf_line_imaging')
 
-                    if arrayname == '12M':
-                        contfile = os.path.join(os.getenv('ALMAIMF_ROOTDIR'),
-                                                "contdat",
-                                                "{field}.{band}.12m.cont.dat".format(field=field, band=band))
-                    else:
-                        raise ValueError("Continuum subtraction for non-12m data "
-                                         "is not yet implemented.  We need to "
-                                         "contsub the 7m and 12m datasets "
-                                         "separately because of their differing "
-                                         "channel layout."
-                                        )
-                    if not os.path.exists(contfile):
-                        contfile = os.path.join(os.getenv('ALMAIMF_ROOTDIR'),
-                                                "contdat",
-                                                "{field}.{band}.cont.dat".format(field=field, band=band))
-                    if not os.path.exists(contfile):
-                        contfile = os.path.join(path, '../calibration/cont.dat')
+                    # TEMPORARY HACK:
+                    # These next two lines should be replaced with code that merges all cont.dat's
+                    muid = list(metadata[band][field]['cont.dat'].keys())[0]
+                    contfile = metadata[band][field]['cont.dat'][muid]
 
                     cont_freq_selection = parse_contdotdat(contfile)
                     logprint("Selected {0} as continuum channels".format(cont_freq_selection), origin='almaimf_line_imaging')

--- a/reduction/line_imaging.py
+++ b/reduction/line_imaging.py
@@ -41,6 +41,7 @@ except ImportError:
 from parse_contdotdat import parse_contdotdat, freq_selection_overlap, contchannels_to_linechannels
 from metadata_tools import determine_imsize, determine_phasecenter, is_7m, logprint
 from imaging_parameters import line_imaging_parameters, selfcal_pars, line_parameters
+from unite_contranges import merge_contdotdat
 from taskinit import msmdtool, iatool, mstool
 from metadata_tools import effectiveResolutionAtFreq
 from create_clean_model import create_clean_model
@@ -312,10 +313,10 @@ for band in band_list:
                     logprint("Concatvis contsub {0}.contsub does not exist, doing continuum subtraction.".format(str(concatvis)),
                              origin='almaimf_line_imaging')
 
-                    # TEMPORARY HACK:
-                    # These next two lines should be replaced with code that merges all cont.dat's
-                    muid = list(metadata[band][field]['cont.dat'].keys())[0]
-                    contfile = metadata[band][field]['cont.dat'][muid]
+                    contfile12m, contfile7m = merge_contdotdat(band, field,
+                                                               basepath='.',
+                                                               datfiles=metadata[band][field]['cont.dat'].values())
+                    contfile = contfile12m
 
                     cont_freq_selection = parse_contdotdat(contfile)
                     logprint("Selected {0} as continuum channels".format(cont_freq_selection), origin='almaimf_line_imaging')

--- a/reduction/split_windows.py
+++ b/reduction/split_windows.py
@@ -206,8 +206,10 @@ for sg in science_goals:
 
                 if 'muid_configs' in metadata[band][field]:
                     metadata[band][field]['muid_configs'][array_config] = muid
+                    metadata[band][field]['max_bl'][muid] = max_bl
                 else:
                     metadata[band][field]['muid_configs'] = {array_config: muid}
+                    metadata[band][field]['max_bl'] = {muid: max_bl}
 
 
                 # Custom cont.dat files:
@@ -236,16 +238,17 @@ for sg in science_goals:
                         metadata[band][field]['cont.dat'][muid] = contdatpath
                     else:
                         metadata[band][field]['cont.dat'] = {muid: contdatpath}
-                        metadata[band][field]['max_bl'] = {muid: max_bl}
                 else:
                     if 'cont.dat' in metadata[band][field]:
-                        if max_bl in metadata[band][field]['cont.dat']:
-                            logprint("*** Found DUPLICATE KEY={max_bl} in cont.dat metadata for band={band} field={field}"
-                                     .format(max_bl=max_bl, band=band, field=field))
+                        if muid in metadata[band][field]['cont.dat']:
+                            logprint("*** Found DUPLICATE KEY={muid},{max_bl}"
+                                     " in cont.dat metadata for band={band} field={field}"
+                                     .format(max_bl=max_bl, muid=muid,
+                                             band=band, field=field))
                         else:
-                            metadata[band][field]['cont.dat'][max_bl] = 'notfound_'+ ran_findcont
+                            metadata[band][field]['cont.dat'][muid] = 'notfound_'+ ran_findcont
                     else:
-                        metadata[band][field]['cont.dat'] = {max_bl: 'notfound_'+ ran_findcont}
+                        metadata[band][field]['cont.dat'] = {muid: 'notfound_'+ ran_findcont}
                     contdat_files[field + band + muid] = 'notfound_'+ ran_findcont
 
                 # touch the filename

--- a/reduction/unite_contranges.py
+++ b/reduction/unite_contranges.py
@@ -41,8 +41,10 @@ def merge_contdotdat(field,band,basepath='/orange/adamginsburg/ALMA_IMF/2017.1.0
 
         # Open the files to which we will write the final, merged contranges,
         # and write field name at the top
-        f_12m = open(field+'.'+band+'.12m.cont.dat','w')
-        f_7m = open(field+'.'+band+'.7m.cont.dat','w')
+        fn12m = field+'.'+band+'.12m.cont.dat'
+        fn7m = field+'.'+band+'.7m.cont.dat'
+        f_12m = open(fn12m,'w')
+        f_7m = open(fn7m,'w')
         f_12m.write('Field: %s\n\n' % (field))
         f_7m.write('Field: %s\n\n' % (field))
 
@@ -164,3 +166,5 @@ def merge_contdotdat(field,band,basepath='/orange/adamginsburg/ALMA_IMF/2017.1.0
         #Once you have finished iterating over all spws, close the output files
         f_12m.close()
         f_7m.close()
+
+        return fn12m, fn7m


### PR DESCRIPTION
The uvcontsub approach taken in `line_imaging` previously was an utter hack and not well thought out.  We were using one of three cont.dats blithely ignoring that they can be dramatically different.

This version still does that, but at least it doesn't reproduce code used elsewhere, which resulted in inconsistent usage of cont.dat files.

Once https://github.com/ALMA-IMF/reduction/pull/104 is complete, I'll revise this to use the merged cont.dats on the fly.