### PR TITLE
New thresholds and cubewidths for SiO-only cubes

### DIFF
--- a/reduction/imaging_parameters.py
+++ b/reduction/imaging_parameters.py
@@ -2780,9 +2780,13 @@ line_imaging_parameters_custom = {
         "startmodel": "G008.67_B3_uid___A001_X1296_X1c1_continuum_merged_12M_robust0_selfcal5_finaliter",
     },
     "G008.67_B6_12M_robust0": {
-        "threshold": "28mJy",
+        "threshold": "28mJy",#estimated noise: 9-11 mJy, from sio-only cube
         # "startmodel": "G008.67_B6_uid___A001_X1296_X1b9_continuum_merged_12M_robust0_selfcal5_finaliter",
         # UF machine has 1b9 instead of 1b7 as of 10/14/2020 - this may change
+        "startmodel": "G008.67_B6_uid___A001_X1296_X1b7_continuum_merged_12M_robust0_selfcal5_finaliter",
+    },
+    "G008.67_B6_spw1_12M_sio":{
+        "threshold": "33mJy", #typical rms is 9-11 mJy, using 3sigma for threshold (14 Dec. 2020)
         "startmodel": "G008.67_B6_uid___A001_X1296_X1b7_continuum_merged_12M_robust0_selfcal5_finaliter",
     },
     "G010.62_B3_12M_robust0": {
@@ -2792,9 +2796,13 @@ line_imaging_parameters_custom = {
         "startmodel": "G010.62_B3_uid___A001_X1296_X1e5_continuum_merged_12M_robust0_selfcal7_finaliter",
     },
     "G010.62_B6_12M_robust0": {
-        "threshold": "6mJy",
+        "threshold": "6mJy", #estimated noise: 2.8-3.2 mJy, from sio-only cube
         # "startmodel": "G010.62_B6_uid___A001_X1296_X1df_continuum_merged_12M_robust0_selfcal5_finaliter",
         # UF machine has 1db instead of 1df as of 10/16/2020 - this may change
+        "startmodel": "G010.62_B6_uid___A001_X1296_X1db_continuum_merged_12M_robust0_selfcal5_finaliter",
+    },
+    "G010.62_B6_spw1_12M_sio":{
+        "threshold": "9.6mJy", #typical rms is 2.8-3.2 mJy, using 3sigma for threshold (14 Dec. 2020)
         "startmodel": "G010.62_B6_uid___A001_X1296_X1db_continuum_merged_12M_robust0_selfcal5_finaliter",
     },
     "G012.80_B3_12M_robust0": {
@@ -2804,9 +2812,13 @@ line_imaging_parameters_custom = {
         "startmodel": "G012.80_B3_uid___A001_X1296_X1fb_continuum_merged_12M_robust0_selfcal5_finaliter",
     },
     "G012.80_B6_12M_robust0": {
-        "threshold": "24mJy",
+        "threshold": "24mJy", #estimated noise: , from sio-only cube
         # "startmodel": "G012.80_B6_uid___A001_X1296_X1f1_continuum_merged_12M_robust0_selfcal5_finaliter",
         # UF machine has 1ef instead of 1f1 as of 10/16/2020 - this may change
+        "startmodel": "G012.80_B6_uid___A001_X1296_X1ef_continuum_merged_12M_robust0_selfcal5_finaliter",
+    },
+    "G012.80_B6_spw1_12M_sio":{
+        "threshold": "24mJy", #this needs to be updated with values from the most recent sio cube (14 Dec. 2020)
         "startmodel": "G012.80_B6_uid___A001_X1296_X1ef_continuum_merged_12M_robust0_selfcal5_finaliter",
     },
     "G327.29_B3_12M_robust0": {
@@ -2816,7 +2828,11 @@ line_imaging_parameters_custom = {
         "startmodel": "G327.29_B3_uid___A001_X1296_X17d_continuum_merged_12M_robust0_selfcal2_finaliter",
     },
     "G327.29_B6_12M_robust0": {
-        "threshold": "6mJy",
+        "threshold": "6mJy", #estimated noise: 9.5-11.5 mJy, from sio-only cube
+        "startmodel": "G327.29_B6_uid___A001_X1296_X175_continuum_merged_12M_robust0_selfcal5_finaliter",
+    },
+    "G327.29_B6_spw1_12M_sio":{
+        "threshold":"34.5mJy",#typical rms 9.5-11.5 mJy, using 3sigma for threshold (14 Dec. 2020)
         "startmodel": "G327.29_B6_uid___A001_X1296_X175_continuum_merged_12M_robust0_selfcal5_finaliter",
     },
     #   Missing startmodel continuum B3 image
@@ -2825,9 +2841,13 @@ line_imaging_parameters_custom = {
     # 		"startmodel": ""
     # 	},
     "G328.25_B6_12M_robust0": {
-        "threshold": "6mJy",
+        "threshold": "6mJy", #estimated noise: 15-20 mJy, from sio-only cube
         # "startmodel": "G328.25_B6_uid___A001_X1296_X161_continuum_merged_12M_robust0_selfcal5_finaliter",
         # UF machine has 163 instead of 161 as of 10/14/2020 - this may change
+        "startmodel": "G328.25_B6_uid___A001_X1296_X163_continuum_merged_12M_robust0_selfcal4_finaliter",
+    },
+    "G328.25_B6_spw1_12M_sio":{
+        "threshold": "60mJy", #typical rms is 15-20 mJy, using 3sigma for threshold (14 Dec. 2020)
         "startmodel": "G328.25_B6_uid___A001_X1296_X163_continuum_merged_12M_robust0_selfcal4_finaliter",
     },
     "G333.60_B3_12M_robust0": {
@@ -2836,7 +2856,11 @@ line_imaging_parameters_custom = {
         "startmodel": "G333.60_B3_uid___A001_X1296_X1a3_continuum_merged_12M_robust0_selfcal5_finaliter",
     },
     "G333.60_B6_12M_robust0": {
-        "threshold": "6mJy",
+        "threshold": "6mJy",#estimated noise: 4.3-5.2 mJy, from sio-only cube
+        "startmodel": "G333.60_B6_uid___A001_X1296_X19b_continuum_merged_12M_robust0_selfcal5_finaliter",
+    },
+    "G333.60_B6_spw1_12M_sio":{
+        "threshold": "15.6mJy", #typical rms is 4.3-5.2 mJy, using 3sigma for threshold (14 Dec. 2020)
         "startmodel": "G333.60_B6_uid___A001_X1296_X19b_continuum_merged_12M_robust0_selfcal5_finaliter",
     },
     "G337.92_B3_12M_robust0": {
@@ -2846,7 +2870,11 @@ line_imaging_parameters_custom = {
         "startmodel": "G337.92_B3_uid___A001_X1296_X147_continuum_merged_12M_robust0_selfcal4_finaliter",
     },
     "G337.92_B6_12M_robust0": {
-        "threshold": "12mJy",
+        "threshold": "12mJy", #estimated noise: 4.8-5.6 mJy, from sio-only cube
+        "startmodel": "G337.92_B6_uid___A001_X1296_X13b_continuum_merged_12M_robust0_selfcal4_finaliter",
+    },
+    "G337.92_B6_spw1_12M_sio":{
+        "threshold": "16.8mJy",#typical rms 4.8-5.6 mJy, using 3sigma for threshold (14 Dec. 2020)
         "startmodel": "G337.92_B6_uid___A001_X1296_X13b_continuum_merged_12M_robust0_selfcal4_finaliter",
     },
     "G338.93_B3_12M_robust0": {
@@ -2856,7 +2884,11 @@ line_imaging_parameters_custom = {
         "startmodel": "G338.93_B3_uid___A001_X1296_X159_continuum_merged_12M_robust0_selfcal3_finaliter",
     },
     "G338.93_B6_12M_robust0": {
-        "threshold": "6mJy",
+        "threshold": "6mJy", #estimated noise: 5-6 mJy, from sio-only cube
+        "startmodel": "G338.93_B6_uid___A001_X1296_X14f_continuum_merged_12M_robust0_selfcal6_finaliter",
+    },
+    "G338.93_B6_spw1_12M_sio":{
+        "threshold": "18mJy", #typical rms in 5-6 mJy, using 3sigma for threshold (14 Dec. 2020)
         "startmodel": "G338.93_B6_uid___A001_X1296_X14f_continuum_merged_12M_robust0_selfcal6_finaliter",
     },
     "G351.77_B3_12M_robust0": {
@@ -2864,7 +2896,11 @@ line_imaging_parameters_custom = {
         "startmodel": "G351.77_B3_uid___A001_X1296_X209_continuum_merged_12M_robust0_selfcal4_finaliter",
     },
     "G351.77_B6_12M_robust0": {
-        "threshold": "6mJy",
+        "threshold": "6mJy",#estimated noise: 12-16 mJy, from sio-only cube
+        "startmodel": "G351.77_B6_uid___A001_X1296_X201_continuum_merged_12M_robust0_selfcal4_finaliter",
+    },
+    "G351.77_B6_spw1_12M_sio":{
+        "threshold": "48mJy",#typical rms is 12-16 mJy, using 3sigma for threshold (14 Dec. 2020)
         "startmodel": "G351.77_B6_uid___A001_X1296_X201_continuum_merged_12M_robust0_selfcal4_finaliter",
     },
     "G353.41_B3_12M_robust0": {
@@ -2873,9 +2909,13 @@ line_imaging_parameters_custom = {
         "startmodel": "G353.41_B3_uid___A001_X1296_X1d5_continuum_merged_12M_robust0_selfcal6_finaliter",
     },
     "G353.41_B6_12M_robust0": {
-        "threshold": "6mJy",
+        "threshold": "6mJy", #estimated noise: 12.5-16 mJy, from sio-only cube
         # "startmodel": "G353.41_B6_uid___A001_X1296_X1cb_continuum_merged_12M_robust0_selfcal3_finaliter",
         # UF machine has 1c9 selfcal6 instead of 1cb selfcal3 as of 10/15/2020 - this may change
+        "startmodel": "G353.41_B6_uid___A001_X1296_X1c9_continuum_merged_12M_robust0_selfcal6_finaliter",
+    },
+    "G353.41_B6_spw1_12M_sio":{
+        "threshold": "48mJy", #typical rms is 12.5-16 mJy, using 3sigma for threshold (14 Dec. 2020)
         "startmodel": "G353.41_B6_uid___A001_X1296_X1c9_continuum_merged_12M_robust0_selfcal6_finaliter",
     },
     "W43-MM1_B3_12M_robust0": {
@@ -2891,36 +2931,52 @@ line_imaging_parameters_custom = {
         "startmodel": "W43-MM2_B3_uid___A001_X1296_X11b_continuum_merged_12M_robust0_selfcal4_finaliter",
     },
     "W43-MM2_B6_12M_robust0": {
-        "threshold": "6mJy",
+        "threshold": "6mJy", #estimated noise: 2.7 mJy, from sio-only cube
         # NOTE: 111/113 name ambiguous
         "startmodel": "W43-MM2_B6_uid___A001_X1296_X113_continuum_merged_12M_robust0_selfcal5_finaliter",
         "imsize": [1280, 1280],
+    },
+    "W43-MM2_B6_spw1_12M_sio":{
+        "threshold": "8.1mJy",#typical rms: 2.3-2.7 mJy, using 3sigma for threshold (14 Dec. 2020)
+        "startmodel": "W43-MM2_B6_uid___A001_X1296_X113_continuum_merged_12M_robust0_selfcal5_finaliter",
     },
     "W43-MM3_B3_12M_robust0": {
         "threshold": "6mJy",
         "startmodel": "W43-MM3_B3_uid___A001_X1296_X12f_continuum_merged_12M_robust0_selfcal5_finaliter",
     },
     "W43-MM3_B6_12M_robust0": {
-        "threshold": "6mJy",
+        "threshold": "6mJy", #estimated noise: 3.1 mJy, from sio-only cube
         "startmodel": "W43-MM3_B6_uid___A001_X1296_X129_continuum_merged_12M_robust0_selfcal5_finaliter",
         "imsize": [1280, 1280],
     },
-    "W51-E_B6_12M_robust0": {
-        "pblimit": 0.1,
-        "threshold": "16mJy",  # sigma is ~4 mJy
-        "startmodel": "W51-E_B6_uid___A001_X1296_X213_continuum_merged_12M_robust0_selfcal7_finaliter",
+    "W43-MM3_B6_spw1_12M_sio":{
+        "threshold": "9.3mJy",#typical rms is 2.7-3.1 mJy, using 3sigma for threshold (14 Dec. 2020)
+        "startmodel": "W43-MM3_B6_uid___A001_X1296_X129_continuum_merged_12M_robust0_selfcal5_finaliter",
     },
     "W51-E_B3_12M_robust0": {
         "startmodel": "W51-E_B3_uid___A001_X1296_X10b_continuum_merged_12M_robust0_selfcal4",
         "threshold": "4mJy",  # sigma is ~0.8 mJy
         "pblimit": 0.05,  # per Nov 6 telecon
     },
+    "W51-E_B6_12M_robust0": {
+        "pblimit": 0.1,
+        "threshold": "16mJy",  # sigma is ~ 4 mJy  (from sio cube, noise is 3.3-4.1 mJy)
+        "startmodel": "W51-E_B6_uid___A001_X1296_X213_continuum_merged_12M_robust0_selfcal7_finaliter",
+    },
+    "W51-E_B6_spw1_12M_sio":{
+        "threshold": "12.3mJy",#typical rms is 3.3-4.1 mJy, using 3sigma for threshold (14 Dec. 2020)
+        "startmodel": "W51-E_B6_uid___A001_X1296_X213_continuum_merged_12M_robust0_selfcal7_finaliter",
+    },
     "W51-IRS2_B3_12M_robust0": {
         "threshold": "6mJy",
         "startmodel": "W51-IRS2_B3_uid___A001_X1296_X18f_continuum_merged_12M_robust0_selfcal4_finaliter",
     },
     "W51-IRS2_B6_12M_robust0": {
-        "threshold": "6mJy",
+        "threshold": "6mJy", #estimated noise: 3.2 mJy, from sio-only cube
+        "startmodel": "W51-IRS2_B6_uid___A001_X1296_X187_continuum_merged_12M_robust0_selfcal8_finaliter",
+    },
+    "W51-IRS2_B6_spw1_12M_sio":{
+        "threshold": "9.6mJy",#typical rms is 2.7-3.2 mJy, using 3sigma for threshold (14 Dec. 2020)
         "startmodel": "W51-IRS2_B6_uid___A001_X1296_X187_continuum_merged_12M_robust0_selfcal8_finaliter",
     },
 }
@@ -2977,13 +3033,14 @@ line_parameters = copy.deepcopy(line_parameters_default)
 line_parameters_custom = {
     "G008.67": {
         "12co": {"cubewidth": "150km/s"},
+        "sio": {"cubewidth": "60km/s"},
         "ch3cn": {"cubewidth": "150km/s"},
         "h41a": {"cubewidth": "120km/s", "vlsr": "44km/s"},
         "h30a": {"cubewidth": "120km/s", "vlsr": "44km/s"},
     },
     "G010.62": {
         "12co": {"cubewidth": "150km/s"},
-        "sio": {"cubewidth": "150km/s"},
+        "sio": {"cubewidth": "60km/s"},
         "ch3cn": {"cubewidth": "150km/s"},
         "h41a": {"cubewidth": "120km/s", "vlsr": "0km/s"},
         "h30a": {"cubewidth": "120km/s", "vlsr": "0km/s"},
@@ -2997,18 +3054,21 @@ line_parameters_custom = {
     },
     "G327.29": {
         "12co": {"cubewidth": "150km/s"},
+        "sio": {"cubewidth": "70km/s"},
         "ch3cn": {"cubewidth": "150km/s"},
         "h41a": {"cubewidth": "120km/s", "vlsr": "-40km/s"},
         "h30a": {"cubewidth": "120km/s", "vlsr": "-40km/s"},
     },
     "G328.25": {
         "12co": {"cubewidth": "150km/s"},
+        "sio": {"cubewidth": "70km/s"},
         "ch3cn": {"cubewidth": "150km/s"},
         "h41a": {"cubewidth": "120km/s", "vlsr": "-37km/s"},
         "h30a": {"cubewidth": "120km/s", "vlsr": "-37km/s"},
     },
     "G333.60": {
         "12co": {"cubewidth": "150km/s"},
+        "sio": {"cubewidth": "60km/s"},
         "ch3cn": {"cubewidth": "150km/s"},
         "h41a": {"cubewidth": "120km/s", "vlsr": "-44km/s"},
         "h30a": {"cubewidth": "120km/s", "vlsr": "-44km/s"},
@@ -3021,6 +3081,7 @@ line_parameters_custom = {
     },
     "G338.93": {
         "12co": {"cubewidth": "150km/s"},
+        "sio": {"cubewidth": "60km/s"},
         "ch3cn": {"cubewidth": "150km/s"},
         "h41a": {"cubewidth": "120km/s", "vlsr": "-63km/s"},
         "h30a": {"cubewidth": "120km/s", "vlsr": "-63km/s"},
@@ -3028,6 +3089,7 @@ line_parameters_custom = {
     },
     "G351.77": {
         "12co": {"cubewidth": "150km/s"},
+        "sio": {"cubewidth": "70km/s"},
         "ch3cn": {"cubewidth": "150km/s"},
         "h41a": {"cubewidth": "120km/s", "vlsr": "-3.0km/s"},
         "h30a": {"cubewidth": "120km/s", "vlsr": "-3.0km/s"},
@@ -3047,6 +3109,7 @@ line_parameters_custom = {
     },
     "W43-MM2": {
         "12co": {"cubewidth": "150km/s"},
+        "sio": {"cubewidth": "60km/s", "vlsr": "90km/s"},
         "ch3cn": {"cubewidth": "150km/s"},
         "h41a": {"cubewidth": "120km/s", "vlsr": "103km/s"},
         "h30a": {"cubewidth": "120km/s", "vlsr": "103km/s"},
@@ -3069,6 +3132,7 @@ line_parameters_custom = {
     },
     "W51-IRS2": {
         "12co": {"cubewidth": "150km/s"},
+        "sio": {"cubewidth": "70km/s"},
         "ch3cn": {"cubewidth": "150km/s"},
         "h41a": {"cubewidth": "120km/s", "vlsr": "56km/s"},
         "h30a": {"cubewidth": "120km/s", "vlsr": "56km/s"},

--- a/reduction/imaging_parameters.py
+++ b/reduction/imaging_parameters.py
@@ -2780,7 +2780,7 @@ line_imaging_parameters_custom = {
         "startmodel": "G008.67_B3_uid___A001_X1296_X1c1_continuum_merged_12M_robust0_selfcal5_finaliter",
     },
     "G008.67_B6_12M_robust0": {
-        "threshold": "28mJy",#estimated noise: 9-11 mJy, from sio-only cube
+        "threshold": "33mJy", #"28mJy",#estimated noise: 9-11 mJy, from sio-only cube
         # "startmodel": "G008.67_B6_uid___A001_X1296_X1b9_continuum_merged_12M_robust0_selfcal5_finaliter",
         # UF machine has 1b9 instead of 1b7 as of 10/14/2020 - this may change
         "startmodel": "G008.67_B6_uid___A001_X1296_X1b7_continuum_merged_12M_robust0_selfcal5_finaliter",
@@ -2796,7 +2796,7 @@ line_imaging_parameters_custom = {
         "startmodel": "G010.62_B3_uid___A001_X1296_X1e5_continuum_merged_12M_robust0_selfcal7_finaliter",
     },
     "G010.62_B6_12M_robust0": {
-        "threshold": "6mJy", #estimated noise: 2.8-3.2 mJy, from sio-only cube
+        "threshold": "9.6mJy",#"6mJy", #estimated noise: 2.8-3.2 mJy, from sio-only cube
         # "startmodel": "G010.62_B6_uid___A001_X1296_X1df_continuum_merged_12M_robust0_selfcal5_finaliter",
         # UF machine has 1db instead of 1df as of 10/16/2020 - this may change
         "startmodel": "G010.62_B6_uid___A001_X1296_X1db_continuum_merged_12M_robust0_selfcal5_finaliter",
@@ -2818,7 +2818,7 @@ line_imaging_parameters_custom = {
         "startmodel": "G012.80_B6_uid___A001_X1296_X1ef_continuum_merged_12M_robust0_selfcal5_finaliter",
     },
     "G012.80_B6_spw1_12M_sio":{
-        "threshold": "24mJy", #this needs to be updated with values from the most recent sio cube (14 Dec. 2020)
+        "threshold": "24mJy", #this needs to be updated with values from the most recent sio cube once it is made (14 Dec. 2020)
         "startmodel": "G012.80_B6_uid___A001_X1296_X1ef_continuum_merged_12M_robust0_selfcal5_finaliter",
     },
     "G327.29_B3_12M_robust0": {
@@ -2828,7 +2828,7 @@ line_imaging_parameters_custom = {
         "startmodel": "G327.29_B3_uid___A001_X1296_X17d_continuum_merged_12M_robust0_selfcal2_finaliter",
     },
     "G327.29_B6_12M_robust0": {
-        "threshold": "6mJy", #estimated noise: 9.5-11.5 mJy, from sio-only cube
+        "threshold": "34.5mJy",#"6mJy", #estimated noise: 9.5-11.5 mJy, from sio-only cube
         "startmodel": "G327.29_B6_uid___A001_X1296_X175_continuum_merged_12M_robust0_selfcal5_finaliter",
     },
     "G327.29_B6_spw1_12M_sio":{
@@ -2841,13 +2841,13 @@ line_imaging_parameters_custom = {
     # 		"startmodel": ""
     # 	},
     "G328.25_B6_12M_robust0": {
-        "threshold": "6mJy", #estimated noise: 15-20 mJy, from sio-only cube
+        "threshold": "63mJy",#"6mJy", #estimated noise: 15-21 mJy, from sio-only cube
         # "startmodel": "G328.25_B6_uid___A001_X1296_X161_continuum_merged_12M_robust0_selfcal5_finaliter",
         # UF machine has 163 instead of 161 as of 10/14/2020 - this may change
         "startmodel": "G328.25_B6_uid___A001_X1296_X163_continuum_merged_12M_robust0_selfcal4_finaliter",
     },
     "G328.25_B6_spw1_12M_sio":{
-        "threshold": "60mJy", #typical rms is 15-20 mJy, using 3sigma for threshold (14 Dec. 2020)
+        "threshold": "63mJy", #typical rms is 15-21 mJy, using 3sigma for threshold (14 Dec. 2020)
         "startmodel": "G328.25_B6_uid___A001_X1296_X163_continuum_merged_12M_robust0_selfcal4_finaliter",
     },
     "G333.60_B3_12M_robust0": {
@@ -2856,7 +2856,7 @@ line_imaging_parameters_custom = {
         "startmodel": "G333.60_B3_uid___A001_X1296_X1a3_continuum_merged_12M_robust0_selfcal5_finaliter",
     },
     "G333.60_B6_12M_robust0": {
-        "threshold": "6mJy",#estimated noise: 4.3-5.2 mJy, from sio-only cube
+        "threshold": "15.6mJy",#"6mJy",#estimated noise: 4.3-5.2 mJy, from sio-only cube
         "startmodel": "G333.60_B6_uid___A001_X1296_X19b_continuum_merged_12M_robust0_selfcal5_finaliter",
     },
     "G333.60_B6_spw1_12M_sio":{
@@ -2870,7 +2870,7 @@ line_imaging_parameters_custom = {
         "startmodel": "G337.92_B3_uid___A001_X1296_X147_continuum_merged_12M_robust0_selfcal4_finaliter",
     },
     "G337.92_B6_12M_robust0": {
-        "threshold": "12mJy", #estimated noise: 4.8-5.6 mJy, from sio-only cube
+        "threshold": "16.8mJy",#"12mJy", #estimated noise: 4.8-5.6 mJy, from sio-only cube
         "startmodel": "G337.92_B6_uid___A001_X1296_X13b_continuum_merged_12M_robust0_selfcal4_finaliter",
     },
     "G337.92_B6_spw1_12M_sio":{
@@ -2884,7 +2884,7 @@ line_imaging_parameters_custom = {
         "startmodel": "G338.93_B3_uid___A001_X1296_X159_continuum_merged_12M_robust0_selfcal3_finaliter",
     },
     "G338.93_B6_12M_robust0": {
-        "threshold": "6mJy", #estimated noise: 5-6 mJy, from sio-only cube
+        "threshold": "18mJy",#"6mJy", #estimated noise: 5-6 mJy, from sio-only cube
         "startmodel": "G338.93_B6_uid___A001_X1296_X14f_continuum_merged_12M_robust0_selfcal6_finaliter",
     },
     "G338.93_B6_spw1_12M_sio":{
@@ -2896,7 +2896,7 @@ line_imaging_parameters_custom = {
         "startmodel": "G351.77_B3_uid___A001_X1296_X209_continuum_merged_12M_robust0_selfcal4_finaliter",
     },
     "G351.77_B6_12M_robust0": {
-        "threshold": "6mJy",#estimated noise: 12-16 mJy, from sio-only cube
+        "threshold": "48mJy",#"6mJy",#estimated noise: 12-16 mJy, from sio-only cube
         "startmodel": "G351.77_B6_uid___A001_X1296_X201_continuum_merged_12M_robust0_selfcal4_finaliter",
     },
     "G351.77_B6_spw1_12M_sio":{
@@ -2909,7 +2909,7 @@ line_imaging_parameters_custom = {
         "startmodel": "G353.41_B3_uid___A001_X1296_X1d5_continuum_merged_12M_robust0_selfcal6_finaliter",
     },
     "G353.41_B6_12M_robust0": {
-        "threshold": "6mJy", #estimated noise: 12.5-16 mJy, from sio-only cube
+        "threshold": "48mJy",#"6mJy", #estimated noise: 12.5-16 mJy, from sio-only cube
         # "startmodel": "G353.41_B6_uid___A001_X1296_X1cb_continuum_merged_12M_robust0_selfcal3_finaliter",
         # UF machine has 1c9 selfcal6 instead of 1cb selfcal3 as of 10/15/2020 - this may change
         "startmodel": "G353.41_B6_uid___A001_X1296_X1c9_continuum_merged_12M_robust0_selfcal6_finaliter",
@@ -2931,7 +2931,7 @@ line_imaging_parameters_custom = {
         "startmodel": "W43-MM2_B3_uid___A001_X1296_X11b_continuum_merged_12M_robust0_selfcal4_finaliter",
     },
     "W43-MM2_B6_12M_robust0": {
-        "threshold": "6mJy", #estimated noise: 2.7 mJy, from sio-only cube
+        "threshold": "8.1mJy",#"6mJy", #estimated noise: 2.7 mJy, from sio-only cube
         # NOTE: 111/113 name ambiguous
         "startmodel": "W43-MM2_B6_uid___A001_X1296_X113_continuum_merged_12M_robust0_selfcal5_finaliter",
         "imsize": [1280, 1280],
@@ -2945,7 +2945,7 @@ line_imaging_parameters_custom = {
         "startmodel": "W43-MM3_B3_uid___A001_X1296_X12f_continuum_merged_12M_robust0_selfcal5_finaliter",
     },
     "W43-MM3_B6_12M_robust0": {
-        "threshold": "6mJy", #estimated noise: 3.1 mJy, from sio-only cube
+        "threshold": "9.3mJy",#"6mJy", #estimated noise: 3.1 mJy, from sio-only cube
         "startmodel": "W43-MM3_B6_uid___A001_X1296_X129_continuum_merged_12M_robust0_selfcal5_finaliter",
         "imsize": [1280, 1280],
     },
@@ -2972,7 +2972,7 @@ line_imaging_parameters_custom = {
         "startmodel": "W51-IRS2_B3_uid___A001_X1296_X18f_continuum_merged_12M_robust0_selfcal4_finaliter",
     },
     "W51-IRS2_B6_12M_robust0": {
-        "threshold": "6mJy", #estimated noise: 3.2 mJy, from sio-only cube
+        "threshold": "9.6mJy",#"6mJy", #estimated noise: 3.2 mJy, from sio-only cube
         "startmodel": "W51-IRS2_B6_uid___A001_X1296_X187_continuum_merged_12M_robust0_selfcal8_finaliter",
     },
     "W51-IRS2_B6_spw1_12M_sio":{


### PR DESCRIPTION
Updated imaging_parameters.py to include new threshold values for sio-only cubes, and new cubewidths where appropriate. Contains updates for all sources except G012.80, which is currently being re-imaged.