### PR TITLE
Create n2hp specific threshold for G338

### DIFF
--- a/reduction/imaging_parameters.py
+++ b/reduction/imaging_parameters.py
@@ -2883,7 +2883,7 @@ line_imaging_parameters_custom = {
         # UF machine has 159 instead of 15b as of 10/16/2020 - this may change
         "startmodel": "G338.93_B3_uid___A001_X1296_X159_continuum_merged_12M_robust0_selfcal3_finaliter",
     },
-    "G338.93_B3_12M_12m_n2hp": {
+    "G338.93_B3_12M_robust0_n2hp": {
         "threshold": "5mJy",
         # "startmodel": "G338.93_B3_uid___A001_X1296_X15b_continuum_merged_12M_robust0_selfcal2_finaliter",
         # UF machine has 159 instead of 15b as of 10/16/2020 - this may change

--- a/reduction/imaging_parameters.py
+++ b/reduction/imaging_parameters.py
@@ -2883,6 +2883,12 @@ line_imaging_parameters_custom = {
         # UF machine has 159 instead of 15b as of 10/16/2020 - this may change
         "startmodel": "G338.93_B3_uid___A001_X1296_X159_continuum_merged_12M_robust0_selfcal3_finaliter",
     },
+    "G338.93_B3_12M_12m_n2hp": {
+        "threshold": "5mJy",
+        # "startmodel": "G338.93_B3_uid___A001_X1296_X15b_continuum_merged_12M_robust0_selfcal2_finaliter",
+        # UF machine has 159 instead of 15b as of 10/16/2020 - this may change
+        "startmodel": "G338.93_B3_uid___A001_X1296_X159_continuum_merged_12M_robust0_selfcal3_finaliter",
+    },
     "G338.93_B6_12M_robust0": {
         "threshold": "18mJy",#"6mJy", #estimated noise: 5-6 mJy, from sio-only cube
         "startmodel": "G338.93_B6_uid___A001_X1296_X14f_continuum_merged_12M_robust0_selfcal6_finaliter",


### PR DESCRIPTION
I updated the G338 n2hp keyword in the dictionary following the Slack thread. The value is the same as the robust0, so no change since my last update. 