### PR TITLE
Line-specific parameters should inherit from the non-line-specific version

### DIFF
--- a/reduction/imaging_parameters.py
+++ b/reduction/imaging_parameters.py
@@ -2994,9 +2994,9 @@ line_imaging_parameters_custom = {
 for key in line_imaging_parameters_custom:
     if key in line_imaging_parameters:
         line_imaging_parameters[key].update(line_imaging_parameters_custom[key])
-    elif "_".join(key.split(["_"])[:-1]) in line_imaging_parameters:
+    elif "_".join(key.split("_")[:-1]) in line_imaging_parameters:
         # special case - strip off the trailing SiO or N2H+ or whatever
-        noline_key = "_".join(key.split(["_"])[:-1])
+        noline_key = "_".join(key.split("_")[:-1])
         line_imaging_parameters[key] = line_imaging_parameters[noline_key]
         line_imaging_parameters[key].update(line_imaging_parameters_custom[key])
     else:

--- a/reduction/imaging_parameters.py
+++ b/reduction/imaging_parameters.py
@@ -2994,6 +2994,11 @@ line_imaging_parameters_custom = {
 for key in line_imaging_parameters_custom:
     if key in line_imaging_parameters:
         line_imaging_parameters[key].update(line_imaging_parameters_custom[key])
+    elif "_".join(key.split(["_"])[:-1]) in line_imaging_parameters:
+        # special case - strip off the trailing SiO or N2H+ or whatever
+        noline_key = "_".join(key.split(["_"])[:-1])
+        line_imaging_parameters[key] = line_imaging_parameters[noline_key]
+        line_imaging_parameters[key].update(line_imaging_parameters_custom[key])
     else:
         line_imaging_parameters[key] = line_imaging_parameters_custom[key]
 

--- a/reduction/line_imaging.py
+++ b/reduction/line_imaging.py
@@ -642,6 +642,10 @@ for band in band_list:
                         # tclean will fail if the imagname.mask exists (and we
                         # know it does; see check above) but a mask is
                         # specified
+                        # (This is only needed if dirty imaging is _not_ run)
+                        logprint("Found an existing mask, but a user mask {0} was specified,"
+                                 " so we are overwriting the existing mask.".format(impars['mask']),
+                                 origin='almaimf_line_imaging')
                         shutil.rmtree(lineimagename+".mask")
                         shutil.copytree(impars['mask'], lineimagename+".mask")
 
@@ -700,6 +704,11 @@ for band in band_list:
                     impars['startmodel'] = ''
                 else:
                     smod = ''
+                if 'mask' in impars:
+                    mask = impars['mask']
+                    impars['mask'] = ''
+                else:
+                    mask = ''
                 tclean(vis=concatvis,
                        imagename=lineimagename,
                        restoringbeam='',
@@ -708,6 +717,7 @@ for band in band_list:
                       )
                 impars['niter'] = niter
                 impars['startmodel'] = smod
+                impars['mask'] = mask
                 for suffix in ('image', 'residual', 'model'):
                     ia.open(lineimagename+"."+suffix)
                     ia.sethistory(origin='almaimf_line_imaging',

--- a/reduction/line_imaging.py
+++ b/reduction/line_imaging.py
@@ -636,6 +636,15 @@ for band in band_list:
                 #         raise ValueError("Mask exists but not specified as user.")
                 if os.path.exists(lineimagename+".mask"):
                     impars['usemask'] = 'user'
+
+                    if 'mask' in impars and impars['mask'] != '':
+                        # this is to handle the case that a user has specified a mask:
+                        # tclean will fail if the imagname.mask exists (and we
+                        # know it does; see check above) but a mask is
+                        # specified
+                        shutil.rmtree(lineimagename+".mask")
+                        shutil.copytree(impars['mask'], lineimagename+".mask")
+
                     impars['mask'] = '' # the mask exists, so CASA can't be told to use it
 
                     if mask_out_endchannels:
@@ -661,7 +670,6 @@ for band in band_list:
                                     )
 
                         ia.close()
-
 
                 # SANITY CHECK:
                 if os.path.exists(lineimagename+".model"):


### PR DESCRIPTION
@apmtowner found this error, which is the cause of the problem @nonyt had described and @rgalvanmadrid had confirmed. It often manifested as, e.g., `niter` being unspecified.