### PR TITLE
updated imaging parameters for SiO cubes for G012, G327, and G328

### DIFF
--- a/reduction/imaging_parameters.py
+++ b/reduction/imaging_parameters.py
@@ -2950,7 +2950,7 @@ line_imaging_parameters_custom = {
         "startmodel": "G327.29_B6_uid___A001_X1296_X175_continuum_merged_12M_robust0_selfcal5_finaliter",
     },
     "G327.29_B6_12M_robust0_sio": {
-        "threshold": "34.5mJy",  # typical rms 9.5-11.5 mJy, using 3sigma for threshold (14 Dec. 2020)
+        "threshold": "30mJy",  # typical rms is 10-12.5 mJy, using 3sigma of lowest value for threshold (15 Sept. 2021)
         "startmodel": "G327.29_B6_uid___A001_X1296_X175_continuum_merged_12M_robust0_selfcal5_finaliter",
     },
     "G328.25_B3_12M_robust0": {
@@ -2969,7 +2969,7 @@ line_imaging_parameters_custom = {
         "startmodel": "G328.25_B6_uid___A001_X1296_X163_continuum_merged_12M_robust0_selfcal4_finaliter",
     },
     "G328.25_B6_12M_robust0_sio": {
-        "threshold": "63mJy",  # typical rms is 15-21 mJy, using 3sigma for threshold (14 Dec. 2020)
+        "threshold": "57mJy",  # typical rms is 18-22 mJy, using 3sigma of 19 mJy for threshold (15 Sept. 2021)
         "startmodel": "G328.25_B6_uid___A001_X1296_X163_continuum_merged_12M_robust0_selfcal4_finaliter",
     },
     "G333.60_B3_12M_robust0": {
@@ -4287,14 +4287,14 @@ line_parameters_custom = {
     },
     "G012.80": {
         "12co": {"cubewidth": "150km/s"},
-        "sio": {"cubewidth": "100km/s", "vlsr": "35.5km/s"},
+        "sio": {"cubewidth": "150km/s", "vlsr": "35.5km/s"},
         "ch3cnv8=1": {"cubewidth": "150km/s"},
         "h41a": {"cubewidth": "270km/s", "vlsr": "-29km/s"},  # 36 - 65 = -29km/s to accomodate He and C.
         "h30a": {"cubewidth": "120km/s", "vlsr": "35km/s"},
     },
     "G327.29": {
         "12co": {"cubewidth": "150km/s"},
-        "sio": {"cubewidth": "120km/s", "vlsr": "-43km/s"},
+        "sio": {"cubewidth": "150km/s", "vlsr": "-43km/s"},
         "ch3cnv8=1": {"cubewidth": "150km/s"},
         "h41a": {"cubewidth": "270km/s", "vlsr": "-105km/s"},  # -40 - 65 = -105km/s to accomodate He and C.
         "h30a": {"cubewidth": "120km/s", "vlsr": "-40km/s"},


### PR DESCRIPTION
Increased width (velocity) for g12, g327; changed (decreased) clean threshold for g327 and g328