### PR TITLE
Flagging channels for B6 spw5 JvM Cubes

### DIFF
--- a/reduction/imaging_parameters.py
+++ b/reduction/imaging_parameters.py
@@ -4395,6 +4395,7 @@ line_parameters_custom = {
         "h30a": {"cubewidth": "120km/s", "vlsr": "-43km/s"},
     },
     "G333.60": {
+        "spw5": {"mask-ranges": [(-56, -48)]},  # km/s units
         "12co": {"cubewidth": "150km/s"},
         "sio": {"cubewidth": "150km/s", "vlsr": "-48km/s"},
         "ch3cnv8=1": {"cubewidth": "150km/s"},
@@ -4403,7 +4404,7 @@ line_parameters_custom = {
     },
     "G337.92": {
         "sio": {"cubewidth": "150km/s", "vlsr": "-39km/s"},
-        "12co": {"cubewidth": "150km/s"},
+        "12co": {"cubewidth": "150km/s", "mask-ranges": [(-56, -48)]},
         "ch3cnv8=1": {"cubewidth": "150km/s"},
         "h41a": {"cubewidth": "270km/s", "vlsr": "-100km/s"},  # -35 - 65 = -100km/s to accomodate He and C.
         "h30a": {"cubewidth": "120km/s", "vlsr": "-35km/s"},
@@ -4425,8 +4426,8 @@ line_parameters_custom = {
         "h30a": {"cubewidth": "120km/s", "vlsr": "-2km/s"},
     },
     "G353.41": {
-        "spw5": {"mask-ranges": [(-27, -20)]},  # km/s units
-        "12co": {"cubewidth": "150km/s", "mask-ranges": [(-27, -20)]},  # km/s units
+        "spw5": {"mask-ranges": [(-29, -20)]},  # km/s units
+        "12co": {"cubewidth": "150km/s", "mask-ranges": [(-29, -20)]},  # km/s units
         "sio": {"cubewidth": "150km/s"},
         "ch3cnv8=1": {"cubewidth": "150km/s"},
         "h41a": {"cubewidth": "270km/s", "vlsr": "-81km/s"},  # -16 - 65 = -81km/s to accomodate He and C.
@@ -4441,8 +4442,9 @@ line_parameters_custom = {
         "h30a": {"cubewidth": "120km/s", "vlsr": "100km/s"},
     },
     "W43-MM2": {
+        "spw5": {"mask-ranges": [(71, 87)]},  # km/s units
         "sio": {"cubewidth": "200km/s", "vlsr": "91km/s", "width": "0.37km/s"},
-        "12co": {"cubewidth": "240km/s", "vlsr": "91km/s"},
+        "12co": {"cubewidth": "240km/s", "vlsr": "91km/s", "mask-ranges": [(71, 87)]},
         # "12co": {"cubewidth": "240km/s", "vlsr": "91km/s", "width": "2km/s"},
         "ch3cnv8=1": {"cubewidth": "150km/s"},
         "h41a": {"cubewidth": "270km/s", "vlsr": "35km/s"},  # 100 - 65 = 35km/s to accomodate He and C.


### PR DESCRIPTION
First, I'm not sure of all the changes proposed. 

G012.80 : I made no changes, but the channels already flagged still have cleaning problems.

G333.60 : No divergence but the "pattern" seems present.

G351.77 : Weird "mosaic" behavior between 267 km/s and 277km/s and between -283km/s and -267km/s (not flagged because I don't know if it's a cleaning problem).
There are a lot of channels with important negative intensity areas --> is it a problem ?
The channels already flagged have no more divergences but still a weird pattern.

G353.41: I just extend a bit the flagged channels by precaution, but the flagged channels have still divergences

W43-MM2: No divergence, but there is the same pattern as before, and again a lot of negative intensity areas on a lot of channels.