### PR TITLE
 Update velocity range to mask for G353 spws 4/5

### DIFF
--- a/reduction/imaging_parameters.py
+++ b/reduction/imaging_parameters.py
@@ -4587,7 +4587,8 @@ line_parameters_custom = {
         "h30a": {"cubewidth": "120km/s", "vlsr": "-2km/s"},
     },
     "G353.41": {
-        "spw5_B6": {"mask-ranges": [(-27, -20)]},  # km/s units
+        "spw4_B6": {"mask-ranges": [(-14, -19)]},  # km/s units
+        "spw5_B6": {"mask-ranges": [(-16, -37)]},  # km/s units
         "12co": {"cubewidth": "150km/s", "mask-ranges": [(-27, -20)]},  # km/s units
         "sio": {"cubewidth": "150km/s"},
         "ch3cnv8=1": {"cubewidth": "150km/s"},


### PR DESCRIPTION
Update velocity ranges to mask due to divergence 
G353.41 B6 spw 4 - Divergence: mask velocity range -14 - 18.3km/s
G353.41 B6 spw 5 - Divergence: makes velocity range -16 -37km/s